### PR TITLE
fix: missing dependency in VSIX, drop `axios`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
         run: bun compile
 
       - name: 🎁 Package extension
-        run: bun vsce package
+        run: bun vsce package --no-dependencies
 
       - name: 🚀 Publish to Visual Studio Marketplace
         run: bun vsce publish
@@ -75,7 +75,7 @@ jobs:
         run: bun compile
 
       - name: 🎁 Package extension
-        run: bun vsce package --out ./vscode-react-native-directory.vsix
+        run: bun vsce package --no-dependencies --out ./vscode-react-native-directory.vsix
 
       - name: 🚀 Publish to Open VSX
         run: bun ovsx publish ./vscode-react-native-directory.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 📋 Dry-running release
         run: bun semantic-release --dry-run
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
 
   create:
     if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.release == 'release' }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "activationEvents": [
     "onCommand:extension.showQuickPick"
   ],
-  "main": "./build/extension.js",
+  "main": "./build/index.js",
   "contributes": {
     "commands": [
       {
@@ -36,13 +36,12 @@
     "vscode": "^1.97.0"
   },
   "scripts": {
-    "compile": "rimraf build && tsc -p .",
-    "lint": "eslint .",
-    "package": "vsce package",
+    "compile": "rimraf build && ncc build src/extension.ts -o build -m",
+    "lint": "tsc --noEmit && eslint .",
+    "package": "vsce package --no-dependencies",
     "release:dry-run": "bun --env-file=.env semantic-release --dry-run"
   },
   "dependencies": {
-    "axios": "^1.7.9",
     "preferred-pm": "^4.1.1"
   },
   "devDependencies": {
@@ -51,6 +50,7 @@
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^22.13.4",
     "@types/vscode": "^1.97.0",
+    "@vercel/ncc": "^0.38.3",
     "@vscode/vsce": "^3.2.2",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^9.20.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./build",
     "module": "commonjs",
     "target": "es2021",
     "lib": ["es2021"],


### PR DESCRIPTION
# Why

Looks like package extension is missing multiple external dependencies, which cause the extension crash.

![Screenshot 2025-02-20 133607](https://github.com/user-attachments/assets/5a79fbf9-c793-45ab-a143-3d5b290aa851)

# How

Drop `axios` in favor of build-in fetch, switch to bundling with `ncc`, so all used external code is put into extension file, guaranteeing existence of all dependencies needed.

# Test plan

Manually installed extension via VSIX works as expected.